### PR TITLE
Create a page for organizing communications in documentation

### DIFF
--- a/packages/docs/docs/communications/organizing-communications.md
+++ b/packages/docs/docs/communications/organizing-communications.md
@@ -1,18 +1,324 @@
 # Organizing Communications
 
-## Background
+# Introduction
 
 Communications in a healthcare context (modeled as [Communication](/docs/api/fhir/resources/communication) resources) can include many scenarios – patient to physician, physician to physician, device to physician, and more. This results in a large volume of communications within this context, so ensuring that they are well organized is vital. For example, a provider may have staff on call to respond to patient messages. Without proper organization, messages may not reach the correct staff member.
 
+This guide covers different ways that you can organize communications and how to think about different properties on the `Communication` element. It will cover:
+
+- Common communication organization patterns, including `Communication.category`, `Communication.topic`, and threading.
+- Searching for communications and threads using the the search helper method from the [Medplum Client SDK](/docs/sdk/classes/MedplumClient)
+- Sorting communications by time
+- How to use different Codesystems to classify communications.
+- Querying for communications.
+
 ## Communication Organization Patterns
 
-There are various ways to organize communications using FHIR, but the most common are `Communication.category` and `Communication.topic`. Additionally, you can use properties such as `Communication.inResponseTo` and `Communication.encounter` to organize communications using threading.
+There are various ways to organize communications using FHIR, but the most common are `Communication.category` and `Communication.topic`. Additionally, you can use properties such as `Communication.inResponseTo` and `Communication.partOf` to organize communications using threading.
 
-The `Communication.category` element is the type of message being conveyed. Categories can include concepts like alerts, notifications, reminders, instructions, etc. Keeping communications well organized by category can help with routing to the correct person/team. For example, communications categorized as appointment reminders that are sent to a patient can automatically be routed to the relevant physician as well, alert categories can be automatically routed to on-call staff during off hours, and instruction categories can be automatically routed to the relevant nurses, patients, physicians, etc.
+## Organizing Using `Communication.category`
 
-The `Communication.topic` element is a description of the content of the communication. It’s easy to think of this as the subject line of an email. Keeping communications well organized by topic can assist with billing and driving workflows. For example, if a patient consults with a physician via phone, this communication can be given a topic of, for example `phone-consult`. Being able to see this topic allows for easy billing to the patient. Additionally, a communication with a `prescription-refill-request` topic is an easy indicator to review this request and fulfill it if necessary.
+The `Communication.category` element is the type of message being conveyed. It allows users to categorize and classify communications into different types or groups based on their purpose, nature, or intended audience. It provides contextual information about the communication, making it easier for users to understand the nature of the message without necessarily having to read or understand the entire communication.
 
-Organizing communications via threading is an effective way to keep related messages grouped together. In healthcare apps, threads can include SMS chains, in-app chats, email exchanges, and more. These threads can constitute an [encounter](/docs/communications/async-encounters/async-encounters), which can be represented on `Communication.encounter`. The `Communication.encounter` element references a specific encounter that is closely related to the communication, or during which the communication took place. In addition, you can use the `Communication.inResponseTo` element. This element is a an array of references to `Communication` elements that preceded the current one and can be useful for tying all the messages in a threads together. Threading communications in this way allows for users to easily view all messages relevant to a single encounter.
+:::tip Note
+
+`Communication.category` is stored as an array of [CodeableConcept](/docs/api/fhir/datatypes/codeableconcept) datatypes, so it is important to note that it is possible for a communication to have multiple categories.
+
+:::
+
+The category property can help in keeping communications organized among the many intricacies of a healthcare setting. For example, you can use it to organize by specific specialties, clinical topics, or the intended audience of a message.
+
+**Example: **
+
+```ts
+{
+  resourceType: 'Communication',
+  id: 'example-communication',
+  category: [
+    {
+      text: 'Doctor',
+      coding: [
+        {
+          code: '158965000',
+          system: 'http://snomed.info/sct'
+        }
+      ]
+    },
+    {
+      text: 'Endocrinology',
+      coding: [
+        {
+          code: '394583002',
+          system: 'http://snomed.info.sct'
+        }
+      ]
+    },
+    {
+      text: 'Diabetes self-management plan',
+      coding: [
+        {
+          code: '735985000',
+          system: 'http://snomed.info.sct'
+        }
+      ]
+    }
+    }
+  ]
+}
+```
+
+`category` is a search parameter on the `Communication` resource, so you can easily search for communications with specific categories. The parameter type is a token, so you will need to search for a specific coded category that your practice has defined. It is possible to search for multiple categories, as shown in the example below. This searches for all communications with the category codes representing 'Doctor' and 'Endocrinology'.
+
+**Example: **
+
+```ts
+await medplum.searchResources('Communication', [
+    ['category', '394583002'],
+    ['category', '158965000']
+  ]
+});
+// OR
+await medplum.searchResources('Communication', 'category=394583002&category=158965000');
+```
+
+```
+curl https://api.medplum.com/fhir/R4/Communication?category=394583002&category=158965000
+```
+
+:::tip Note
+
+There are different ways that you can categorize threads, each one with its own pros and cons. For example, you can have threads with multiple categories, one for specialty and one for level of credentials, etc., where you would search for multiple categories at once. The pros to this are that data model is more self-explanatory, since each category is explicitly represented, and better maintainability, since it is easier to update and add individual categories. However, this can also lead to more complex queries and a more complex data model.
+Alternatively, you can have threads that have just one category that combines specialty, level of credentials, etc., and search for that specific category. This allows for simpler searching, needing only one category search parameter, and a simpler, more compact data model. The downside is that it may require more parsing and logic to handle the combined categories and that as more combinations arise, maintaining the coding system may become complex and difficult to manage.
+
+:::
+
+## Organizing Using `Communication.topic`
+
+The `Communication.topic` element represents a description of the main focus or content of the message. It allows you to link the communication to a specific topic, or subject matter, making it easier for recipients to understand the purpose and content of the message.
+
+It is easy to think of the topic as if it is the subject line of an email for a given communication. In that sense, it is useful to use that level of specificity when defining a topic. For example, a topic could be an appointment for a given patient on a given date. This topic could be assigned to all communications related to that appointment.
+
+**Example: **
+
+```ts
+{
+  resourceType: 'Communication',
+  id: 'example-communication-2',
+  topic: {
+    text: 'In-person appointment with Homer Simpson on April 10th, 2023. Made by telephone.',
+    coding: [
+      {
+        code: '185420007',
+        system: 'http://snomed.info.sct',
+        display: 'In-person appointment made by telephone - Homer Simpson - 04-10-2023'
+      }
+    ]
+  }
+}
+```
+
+## Modeling Threads
+
+You can also use the `Communication` resource to model threading, enabling you to represent the relationship between multiple communications that are part of the same discussion. This is a way to organize related communications and logically link messages so that the context of the conversation is maintained.
+
+Threading can best be modeled using the `Communication.partOf` and `Communication.inResponseTo` elements. These properties allow you to reference other communications, establishing a relationship, or thread, between new and existing communications.
+
+## Threading with `Communication.partOf`
+
+The `partOf` element represents a larger resource of which the communication is a component or step. It can reference any resource type, allowing us to refer to other communications to create a thread. The `partOf` element is best used to create a thread in which each message is linked back to the original parent message, creating an ancestor-descendant relationship.
+
+When creating a thread the initial parent message will not have a value stored in `partOf`. For each response create a new communication resource, setting `partOf` to reference the original communication resource. As the thread grows, each communication should continue to point to that original parent, which will form a group of communications with a common reference point.
+
+In the example below, despite that this is a thread of communications in order, the initial message is the communication being referenced by both responses in the `partOf` property.
+
+**Example: **
+
+```ts
+// The initial communication
+{
+  resourceType: 'Communication',
+  id: 'example-parent-communication',
+  payload: [
+    {
+      contentString: 'We have confirmed your appointment for 10:00am on August 8th.'
+    }
+  ],
+  // There is no `partOf` field on this communication
+}
+
+// A response to the original communication
+{
+  resourceType: 'Communication',
+  id: 'example-response-1',
+  payload: [
+    {
+      contentString: 'Can this appointment be changed to 9:30?'
+    }
+  ],
+  // ...
+  partOf: [
+    {
+      resource: {
+        resourceType: 'Communication',
+        id: 'example-parent-communication'
+      }
+    }
+  ]
+}
+
+// A second response, directly to `example-response-1` but still referencing the parent communication
+{
+  resourceType: 'Communication',
+  id: 'example-response-2',
+  payload: [
+    {
+      contentString: 'Your appointment has been updated to 9:30am on August 8th.'
+    }
+  ],
+  // ...
+  partOf: [
+    {
+      resource: {
+        resourceType: 'Communication',
+        id: 'example-parent-communication'
+      }
+    }
+  ]
+}
+```
+
+:::info Note
+The `partOf` element is not only meant to be used for threading. It is typed as an array of references to any resource, so if a communication is part of a `Procedure`, this can also be included on the element.
+:::
+
+## Threading with `Communication.inResponseTo`
+
+The `inResponseTo` element represents a prior communication that the current communication was created in response to. This element specifically references to other communication resources, allowing us to use it to create linked threads of communications. The `inResponseTo` element is best used to create threads in which each message links to the message it is directly replying to, eventually chaining back to the original communication. This creates a thread with a parent-child relationship between communications.
+
+When creating a thread in this way, the initial communication will not have a value for `inResponseTo`. For each subsequent communication, `inResponseTo` should refer to its parent that it is directly responding to. As the thread grows, this should continue so that each message references its direct parent, creating a chain of messages representing a thread.
+
+In the example below, note that each subsequent communication references the one directly previous to it, creating a chained thread.
+
+**Example: **
+
+```ts
+// The initial communication
+{
+  resourceType: 'Communication',
+  id: 'initial-communication',
+  // ...
+  payload: [
+    {
+      contentString: 'Your medication is ready! Please let us know when you would like to pick it up.'
+    }
+  ]
+  // There is no `inResponseTo` field on this communication
+}
+
+// A response to the initial message
+{
+  resourceType: 'Communication',
+  id: 'response-1',
+  // ...
+  payload: [
+    {
+      contentString: 'I will be in to pick it up tomorrow'
+    }
+  ],
+  inResponseTo: [
+    {
+      // The resource referenced is the message directly prior to this one
+      resource: {
+        resourceType: 'Communication',
+        id: 'initial-communication'
+      }
+    }
+  ],
+  // ...
+}
+
+// Another message in the thread, responding to the previous communication
+{
+  resourceType: 'Communication',
+  id: 'response-2',
+  // ...
+  payload: [
+    {
+      contentString: 'We look forward to seeing you tomorrow! Your medication will be ready to go.'
+    }
+  ],
+  inResponseTo: [
+    {
+      // This message references 'response-1', the message it is directly replying to
+      resource: {
+        resourceType: 'Communication',
+        id: 'response-1'
+      }
+    }
+  ],
+  // ...
+}
+```
+
+## Retrieving Threaded Conversations
+
+Threads can be retrieved with the [Medplum Client SDK](/docs/sdk/classes/MedplumClient) `searchResources` method using special search parameters. If you are using `partOf` to create an ancestor-descendant relationship, you can search for the parent communication as well as any communications that reference it.
+
+**Example: **
+
+```ts
+await medplum.searchResources('Communication', {
+  id: 'example-ancestor-id',
+  _revinclude: 'Communication:part-of',
+});
+```
+
+```
+curl https://api.medplum.com/fhir/R4/Communication?id=example-ancestor-id&_revinclude=Communication:part-of
+```
+
+In this example we are searching for a communication with a given `id`. By including the `_revinclude` parameter, we also search for any communications whose `partOf` property references the communication with the given id. For more details on searching using linked resources, see the [Search](/docs/search/includes) documentation.
+
+If you are using `inResponseTo` to model a parent-child relationship, you can search for the parent communication and then iterate along the thread to get all of the communications.
+
+**Example: **
+
+```ts
+await medplum.searchResources('Communication', {
+  id: 'example-parent-id',
+  _revinclude:iterate: 'Communication:inResponseTo'
+});
+```
+
+In this example we are searching for a communication by `id`. After, we include the `_revinclude:iterate: 'Communication:inResponseTo` parameter, to retrieve all communications that reference the communication we are searching for. By including the `:iterate` modifier to recursively apply the reverse inclusion until no more resources are found. This first finds any direct responses to the initial communication. Then it iterates to find any communications that reference the direct response, and so on until it finds no more communications. For more details on using the `:iterate` modifier, see the [Search](/docs/search/includes) documentation.
+
+## Sorting Communications by Time
+
+Sorting communications by time or organizing messages chronologically is a common requirement when retrieving threaded communications. The communication resource includes two timestamp properties, `sent` and `received`, which represent the time that a message was sent or received. You can search for sorted results by including the special search parameter `_sort`, which allows you to specify a list of search parameters to sort by.
+
+Taking our example from earlier, we could search for a thread that uses `partOf` and sort the results with the below search.
+
+**Example: **
+
+```ts
+await medplum.searchResources('Communication', {
+  id: 'example-id',
+  _revinclude: 'Communication:part-of',
+  _sort: 'sent',
+});
+```
+
+This will return the communications sorted in ascending order. You can also sort by descending order and provide more than one argument to sort by in a comma separated list. The below example sorts the thread by descending time `sent` and then by `sender`.
+
+**Example: **
+
+```ts
+await medplum.searchResources('Communication', {
+  id: 'example-id',
+  _revinclude: 'Communication:part-of',
+  _sort: '-sent,sender',
+});
+```
 
 ## Codesystems
 
@@ -27,11 +333,12 @@ Below is an example of organizing a communication using all three of LOINC, SNOM
 	category: [
 	  // A category coded using LOINC
 		{
-			text: "Alert",
+			text: "Practitioner",
 			coding: [
 				{
-					code: "74018-3"
-					system: "https://fhir.loinc.org",
+					code: "18601-5"
+					system: "http://loinc.org",
+          display: "Primary practitioner profession"
 				}
 			]
 		},
@@ -39,7 +346,7 @@ Below is an example of organizing a communication using all three of LOINC, SNOM
 	//...
 	topic: {
 	  // A topic coded using SNOMED
-		text: "High blood pressure",
+		text: "High blood pressure result for John Doe, from test performed 8/2/2023",
 		coding: [
 			{
 				code: "38341003",
@@ -80,7 +387,7 @@ Below is an example of organizing a communication using all three of LOINC, SNOM
 
 ## Search and GraphQL
 
-Effectively gropuing and filtering your communications makes it easier to search and query for specific data.
+Effectively grouping and filtering your communications makes it easier to search and query for specific data.
 
 For example, if you want to get all of the communications between the provider and a specific patient, you could use the following query. In this, we query for a patient by their id, then search all of the communications that reference them. From these communications, we get the text of the communication, the sender and time it was sent, and the receiver and time it was received. Preview this query in [GraphiQL](graphiql.medplum.com)
 
@@ -88,7 +395,7 @@ For example, if you want to get all of the communications between the provider a
 {
 	# Search for a specific patient by id
   Patient(id: "example-patient-id") {
-    resourceType
+  	resourceType
     id
 		name {
 			family
@@ -96,19 +403,19 @@ For example, if you want to get all of the communications between the provider a
 		}
 		# Search for communications that reference the patient
     communications: CommunicationList(_reference: patient) {
-      text {
+      payload {
         div
       }
       sent
       sender {
         resource {
-          ... Practitioner
+          ... PractitionerDetails
         }
       }
       received
       recipient {
         resource {
-          ... Practitioner
+          ... PatientDetails
         }
       }
     }
@@ -140,12 +447,12 @@ Here is an example of how you could search for all communications within your pr
 		},
 		sender {
 			resource {
-				... Practitioner
+				... PractitionerDetails
 			}
 		},
 		recipient {
 			resource {
-				... Patient
+				... PatientDetails
 			}
 		}
 	}
@@ -166,4 +473,8 @@ fragment PatientDetails on Patient {
 }
 ```
 
-**Note** In these examples, we are only resolving the senders and recipients for one resource type, either Patient or Practitioner. To resolve all potential senders and receivers you will need to include all resource types that can send or receive. For more details on FHIR GraphQL queries see the [GraphQL](/docs/graphql/basic-queries) docs.
+:::tip Note
+
+In these examples, we are only resolving the senders and recipients for one resource type, either Patient or Practitioner. To resolve all potential senders and receivers you will need to include all resource types that can send or receive. For more details on FHIR GraphQL queries see the [GraphQL](/docs/graphql/basic-queries) docs.
+
+:::

--- a/packages/docs/docs/communications/organizing-communications.md
+++ b/packages/docs/docs/communications/organizing-communications.md
@@ -1,32 +1,26 @@
 # Organizing Communications
 
-# Introduction
+## Introduction
 
-Communications in a healthcare context (modeled as [Communication](/docs/api/fhir/resources/communication) resources) can include many scenarios – patient to physician, physician to physician, device to physician, and more. This results in a large volume of communications within this context, so ensuring that they are well organized is vital. For example, a provider may have staff on call to respond to patient messages. Without proper organization, messages may not reach the correct staff member.
+The `Communication` resource represents any messages in a healthcare context. It can include many scenarios – patient to physician, physician to physician, device to physician, and more. This results in a large volume of communications within this context, so ensuring that they are well organized is vital.
 
-This guide covers different ways that you can organize communications and how to think about different properties on the `Communication` element. It will cover:
+This guide covers different ways that you can organize the `Communication` resource. It will cover:
 
-- Common communication organization patterns, including `Communication.category`, `Communication.topic`, and threading.
-- Searching for communications and threads using the the search helper method from the [Medplum Client SDK](/docs/sdk/classes/MedplumClient)
-- Sorting communications by time
-- How to use different Codesystems to classify communications.
-- Querying for communications.
+- Common organization patterns
+  1. How to build and organize threads
+  2. How to "tag" threads and messages
+  3. How to use different Codesystems to classify messages
+- Searching for messages and threads using the the search helper method from the [Medplum Client SDK](/docs/sdk/classes/MedplumClient)
+- Querying for and sorting communications and threads
 
 ## Communication Organization Patterns
 
-There are various ways to organize communications using FHIR, but the most common are `Communication.category` and `Communication.topic`. Additionally, you can use properties such as `Communication.inResponseTo` and `Communication.partOf` to organize communications using threading.
+### Building and Organizing Threads
 
-## Organizing Using `Communication.category`
+The `Communication` resource cann be used to model threading, allowing you to connect multiple related messages that are part of the same discussion. Threading can best be modeled using the `Communication.topic`, `Communication.partOf`, and `Communication.inResponseTo` elements.
+These fields allow you to reference other communications, establishing a relationship, or thread, between new and existing communications.
 
-The `Communication.category` element is the type of message being conveyed. It allows users to categorize and classify communications into different types or groups based on their purpose, nature, or intended audience. It provides contextual information about the communication, making it easier for users to understand the nature of the message without necessarily having to read or understand the entire communication.
-
-:::tip Note
-
-`Communication.category` is stored as an array of [CodeableConcept](/docs/api/fhir/datatypes/codeableconcept) datatypes, so it is important to note that it is possible for a communication to have multiple categories.
-
-:::
-
-The category property can help in keeping communications organized among the many intricacies of a healthcare setting. For example, you can use it to organize by specific specialties, clinical topics, or the intended audience of a message.
+The `Communication.topic` element represents a description of the main focus or content of the message. It allows you to link the communication to a specific topic or subject matter. It is easy to think of the topic as if it is the subject line of an email for a given communication. In that sense, it is useful to use that level of specificity when defining a topic. For example, a topic could be an appointment for a given patient on a given date. By assigning this topic to all `Communication` resources that are related to that appointment, you can create a thread of messages about the appointment. An example of this is below:
 
 **Example: **
 
@@ -34,125 +28,71 @@ The category property can help in keeping communications organized among the man
 {
   resourceType: 'Communication',
   id: 'example-communication',
-  category: [
+  payload: [
     {
-      text: 'Doctor',
-      coding: [
-        {
-          code: '158965000',
-          system: 'http://snomed.info/sct'
-        }
-      ]
-    },
-    {
-      text: 'Endocrinology',
-      coding: [
-        {
-          code: '394583002',
-          system: 'http://snomed.info.sct'
-        }
-      ]
-    },
-    {
-      text: 'Diabetes self-management plan',
-      coding: [
-        {
-          code: '735985000',
-          system: 'http://snomed.info.sct'
-        }
-      ]
-    }
+      contentString: 'Your appointment for a physical on April 10th, 2023 is confirmed.'
     }
   ]
+  topic: {
+    text: 'In-person physical with Homer Simpson on April 10th, 2023.',
+    coding: [
+      {
+        code: 'in-person-appointment-physical-04-10-23',
+        system: 'http://example-practice.com',
+        display: 'In-person appointment for a physical - Homer Simpson - 04-10-2023'
+      }
+    ]
+  }
 }
-```
-
-`category` is a search parameter on the `Communication` resource, so you can easily search for communications with specific categories. The parameter type is a token, so you will need to search for a specific coded category that your practice has defined. It is possible to search for multiple categories, as shown in the example below. This searches for all communications with the category codes representing 'Doctor' and 'Endocrinology'.
-
-**Example: **
-
-```ts
-await medplum.searchResources('Communication', [
-    ['category', '394583002'],
-    ['category', '158965000']
-  ]
-});
-// OR
-await medplum.searchResources('Communication', 'category=394583002&category=158965000');
-```
-
-```
-curl https://api.medplum.com/fhir/R4/Communication?category=394583002&category=158965000
-```
-
-:::tip Note
-
-There are different ways that you can categorize threads, each one with its own pros and cons. For example, you can have threads with multiple categories, one for specialty and one for level of credentials, etc., where you would search for multiple categories at once. The pros to this are that data model is more self-explanatory, since each category is explicitly represented, and better maintainability, since it is easier to update and add individual categories. However, this can also lead to more complex queries and a more complex data model.
-Alternatively, you can have threads that have just one category that combines specialty, level of credentials, etc., and search for that specific category. This allows for simpler searching, needing only one category search parameter, and a simpler, more compact data model. The downside is that it may require more parsing and logic to handle the combined categories and that as more combinations arise, maintaining the coding system may become complex and difficult to manage.
-
-:::
-
-## Organizing Using `Communication.topic`
-
-The `Communication.topic` element represents a description of the main focus or content of the message. It allows you to link the communication to a specific topic, or subject matter, making it easier for recipients to understand the purpose and content of the message.
-
-It is easy to think of the topic as if it is the subject line of an email for a given communication. In that sense, it is useful to use that level of specificity when defining a topic. For example, a topic could be an appointment for a given patient on a given date. This topic could be assigned to all communications related to that appointment.
-
-**Example: **
-
-```ts
+// Although this message is a reminder rather than a confirmation, it references the same appointment, so the same topic is used to thread these together.
 {
   resourceType: 'Communication',
   id: 'example-communication-2',
+  payload: [
+    {
+      contentString: 'This is a reminder that you have an appointment tommorrow, April 10th.'
+    }
+  ]
   topic: {
-    text: 'In-person appointment with Homer Simpson on April 10th, 2023. Made by telephone.',
+    text: 'In-person physical with Homer Simpson on April 10th, 2023.',
     coding: [
       {
-        code: '185420007',
-        system: 'http://snomed.info.sct',
-        display: 'In-person appointment made by telephone - Homer Simpson - 04-10-2023'
+        code: 'in-person-appointment-physical-04-10-23',
+        system: 'http://example-practice.com',
+        display: 'In-person appointment for a physical - Homer Simpson - 04-10-2023'
       }
     ]
   }
 }
 ```
 
-## Modeling Threads
+The `Communication.partOf` element represents a larger resource of which the communication is a component. It can reference any resource type, allowing us to refer to other `Communication` resources to create a thread. The `partOf` element is best used to create a thread in which each message is linked to a single parent message.
 
-You can also use the `Communication` resource to model threading, enabling you to represent the relationship between multiple communications that are part of the same discussion. This is a way to organize related communications and logically link messages so that the context of the conversation is maintained.
+When using the `partOf` field to create a thread, the parent `Communication` resource needs to be distinguished from the children. This is done simply by omitting a message in the `payload` field and a resource referenced in the `partOf` field. Conversely, all children will have both of these fields.
 
-Threading can best be modeled using the `Communication.partOf` and `Communication.inResponseTo` elements. These properties allow you to reference other communications, establishing a relationship, or thread, between new and existing communications.
+Once we have the parent resource, each message in the thread will create a new `Communication` resource, setting `partOf` to reference the parent resource. As more messages are sent, each one will continue to point to the parent, creating a thread with a common reference point.
 
-## Threading with `Communication.partOf`
+It is also important to consider when it is appropriate to use the `Encounter` resource as a top-level grouping mechanism instead of the `Communication` resource. An "encounter" refers to any diagnostic or treatment interaction between a patient and provider, and, in a digital health context, can include SMS chains, in-app threads, and email. The `partOf` field can reference any resource type, so when an "enconter" occurs, threads should be created with the `Encounter` resource as the parent. See the [Representing Asynchronous Encounters](/docs/communications/async-encounters/async-encounters) docs.
 
-The `partOf` element represents a larger resource of which the communication is a component or step. It can reference any resource type, allowing us to refer to other communications to create a thread. The `partOf` element is best used to create a thread in which each message is linked back to the original parent message, creating an ancestor-descendant relationship.
-
-When creating a thread the initial parent message will not have a value stored in `partOf`. For each response create a new communication resource, setting `partOf` to reference the original communication resource. As the thread grows, each communication should continue to point to that original parent, which will form a group of communications with a common reference point.
-
-In the example below, despite that this is a thread of communications in order, the initial message is the communication being referenced by both responses in the `partOf` property.
+In the example below, each message in the thread references the parent `Communication` resource rather than referencing each other.
 
 **Example: **
 
 ```ts
-// The initial communication
+// The parent communication
 {
   resourceType: 'Communication',
   id: 'example-parent-communication',
-  payload: [
-    {
-      contentString: 'We have confirmed your appointment for 10:00am on August 8th.'
-    }
-  ],
   // There is no `partOf` field on this communication
 }
 
-// A response to the original communication
+// The initial communication
 {
   resourceType: 'Communication',
-  id: 'example-response-1',
+  id: 'example-message-1',
   payload: [
     {
-      contentString: 'Can this appointment be changed to 9:30?'
+      contentString: 'Thank you for coming to your appointment! Let us know when you would like to schedule your follow-up.'
     }
   ],
   // ...
@@ -166,13 +106,13 @@ In the example below, despite that this is a thread of communications in order, 
   ]
 }
 
-// A second response, directly to `example-response-1` but still referencing the parent communication
+// A second response, directly to `example-message-1` but still referencing the parent communication
 {
   resourceType: 'Communication',
-  id: 'example-response-2',
+  id: 'example-message-2',
   payload: [
     {
-      contentString: 'Your appointment has been updated to 9:30am on August 8th.'
+      contentString: 'Can I schedule it for two weeks from today?'
     }
   ],
   // ...
@@ -187,17 +127,11 @@ In the example below, despite that this is a thread of communications in order, 
 }
 ```
 
-:::info Note
-The `partOf` element is not only meant to be used for threading. It is typed as an array of references to any resource, so if a communication is part of a `Procedure`, this can also be included on the element.
-:::
+The `Communication.inResponseTo` element represents a prior communication that the current communication was created in response to. This element specifically references other `Communication` resources, allowing us to use it to create linked threads. The `inResponseTo` element is best used to create threads in which each message links to the message it is directly replying to, eventually chaining back to the original communication. This creates a thread similar to a linked-list, where each message points to the previous message in the list.
 
-## Threading with `Communication.inResponseTo`
+When creating a thread in this way, the initial communication will not have a value for `inResponseTo`. For each subsequent communication, `inResponseTo` should refer to the message that it is directly responding to. As the thread grows, this should continue so that each message references the one directly prior to it, creating a linked list of messages representing a thread.
 
-The `inResponseTo` element represents a prior communication that the current communication was created in response to. This element specifically references to other communication resources, allowing us to use it to create linked threads of communications. The `inResponseTo` element is best used to create threads in which each message links to the message it is directly replying to, eventually chaining back to the original communication. This creates a thread with a parent-child relationship between communications.
-
-When creating a thread in this way, the initial communication will not have a value for `inResponseTo`. For each subsequent communication, `inResponseTo` should refer to its parent that it is directly responding to. As the thread grows, this should continue so that each message references its direct parent, creating a chain of messages representing a thread.
-
-In the example below, note that each subsequent communication references the one directly previous to it, creating a chained thread.
+In the example below, note that each subsequent communication references the one directly previous to it, creating a thread.
 
 **Example: **
 
@@ -260,7 +194,100 @@ In the example below, note that each subsequent communication references the one
 }
 ```
 
-## Retrieving Threaded Conversations
+### How to "Tag" Threads and Messages
+
+It can be useful to "tag" threads or individual messages so that a user can easily reference or interpret a certain type of message at a high level. For example, if there is a thread about a task that needs to be performed by a nurse, it can be tagged as such.
+
+Tagging can be effectively done using the `Communication.category` element, which represents the type of message being conveyed. It allows messages to be classified into different types or groups based on specifications like purpose, nature, or intended audience. It is also important to note that the `category` field is an array, so each `Communication` can have multiple tags.
+
+Below is an example of a `Communication` that is tagged with multiple `category` fields, each representing a different specification for the message.
+
+**Example: **
+
+```ts
+{
+  resourceType: 'Communication',
+  id: 'example-communication',
+  category: [
+    {
+      text: 'Doctor',
+      coding: [
+        {
+          code: '158965000',
+          system: 'http://snomed.info/sct'
+        }
+      ]
+    },
+    {
+      text: 'Endocrinology',
+      coding: [
+        {
+          code: '394583002',
+          system: 'http://snomed.info.sct'
+        }
+      ]
+    },
+    {
+      text: 'Diabetes self-management plan',
+      coding: [
+        {
+          code: '735985000',
+          system: 'http://snomed.info.sct'
+        }
+      ]
+    }
+    }
+  ]
+  // ...
+}
+```
+
+:::tip Note
+
+There are different ways that you can categorize threads, each one with its own pros and cons. For example, you can have threads with multiple `category` fields, one for specialty and one for level of credentials, etc., where you would search for multiple categories at once. The pros to this are that the data model is more self-explanatory, since each `category` is explicitly represented, and better maintainability, since it is easier to update and add individual categories. However, this can also lead to more complex queries.
+
+Alternatively, you can have threads that have just one `category` that combines specialty, level of credentials, etc., and search for that specific category. This allows for simpler searching, needing only one `category` search parameter, and a simpler, more compact data model. The downside is that it may require more parsing and logic on the front-end to handle the combined categories and that as more combinations arise, maintaining the coding system may become difficult.
+
+:::
+
+### Codesystems
+
+When classifying the `Communication.category` field, it is best to use SNOMED codes. Specifically, for for practitioner roles and clinical specialty, SNOMED provides the [SNOMED Care Team Member Function](https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.30/expansion) valueset.
+
+When classifying the `topic` element, it is common to use an internal custom coding so you can provide the proper level of specificity. However, it is still possible to use SNOMED and LOINC if you would like to.
+
+```ts
+// A communication with both SNOMED and custom coding
+{
+  resourceType: "Communication",
+	//...
+	category: [
+	  // A category coded using SNOMED
+		{
+			coding: [
+				{
+					code: "158965000"
+					system: "http://snomed.info/sct",
+          display: "Medical Practitioner"
+				}
+			]
+		},
+	],
+	//...
+	topic: {
+	  // A topic coded using a custom coding
+		coding: [
+			{
+				code: "high-blood-pressure-08-02-23-patient=john-doe",
+				system: "http://example-hospital.org",
+				display: "High blood pressure result for John Doe. Test performed 8/2/2023"
+			}
+		]
+	}
+}
+```
+
+## Retrieving Threaded Communications
 
 Threads can be retrieved with the [Medplum Client SDK](/docs/sdk/classes/MedplumClient) `searchResources` method using special search parameters. If you are using `partOf` to create an ancestor-descendant relationship, you can search for the parent communication as well as any communications that reference it.
 
@@ -277,7 +304,25 @@ await medplum.searchResources('Communication', {
 curl https://api.medplum.com/fhir/R4/Communication?id=example-ancestor-id&_revinclude=Communication:part-of
 ```
 
-In this example we are searching for a communication with a given `id`. By including the `_revinclude` parameter, we also search for any communications whose `partOf` property references the communication with the given id. For more details on searching using linked resources, see the [Search](/docs/search/includes) documentation.
+The `category` element is a search parameter on the `Communication` resource, so you can easily search for communications with specific categories. The parameter type is a token, so you will need to search for a specific coded category that your practice has defined. It is possible to search for multiple categories, as shown in the example below. This searches for all communications with the category codes representing 'Doctor' and 'Endocrinology'.
+
+**Example: **
+
+```ts
+await medplum.searchResources('Communication', [
+    ['category', '394583002'],
+    ['category', '158965000']
+  ]
+});
+// OR
+await medplum.searchResources('Communication', 'category=394583002&category=158965000');
+```
+
+```
+curl https://api.medplum.com/fhir/R4/Communication?category=394583002&category=158965000
+```
+
+In this example we are searching for a communication with a given `id`. By including the `_revinclude` parameter, we also search for any communications whose `partOf` element references the communication with the given id. For more details on searching using linked resources, see the [Search](/docs/search/includes) documentation.
 
 If you are using `inResponseTo` to model a parent-child relationship, you can search for the parent communication and then iterate along the thread to get all of the communications.
 
@@ -294,7 +339,7 @@ In this example we are searching for a communication by `id`. After, we include 
 
 ## Sorting Communications by Time
 
-Sorting communications by time or organizing messages chronologically is a common requirement when retrieving threaded communications. The communication resource includes two timestamp properties, `sent` and `received`, which represent the time that a message was sent or received. You can search for sorted results by including the special search parameter `_sort`, which allows you to specify a list of search parameters to sort by.
+Sorting communications by time or organizing messages chronologically is a common requirement when retrieving threaded communications. The communication resource includes two timestamp fields, `sent` and `received`, which represent the time that a message was sent or received. You can search for sorted results by including the special search parameter `_sort`, which allows you to specify a list of search parameters to sort by.
 
 Taking our example from earlier, we could search for a thread that uses `partOf` and sort the results with the below search.
 
@@ -320,157 +365,181 @@ await medplum.searchResources('Communication', {
 });
 ```
 
-## Codesystems
-
-It is recommended to use LOINC or SNOMED codes to classify `Communication.category` and `Communication.topic`, but it is also possible to use custom coding internal to your practice.
-
-Below is an example of organizing a communication using all three of LOINC, SNOMED, and a custom code.
-
-```
-{
-  resourceType: "Communication",
-	//...
-	category: [
-	  // A category coded using LOINC
-		{
-			text: "Practitioner",
-			coding: [
-				{
-					code: "18601-5"
-					system: "http://loinc.org",
-          display: "Primary practitioner profession"
-				}
-			]
-		},
-	],
-	//...
-	topic: {
-	  // A topic coded using SNOMED
-		text: "High blood pressure result for John Doe, from test performed 8/2/2023",
-		coding: [
-			{
-				code: "38341003",
-				system: "http://snomed.info/sct",
-				display: "Hypertensive Disorder"
-			}
-		]
-	}
-}
-
-{
-	resourceType: "Communication",
-	//...
-	// An example of how an internal custom coding could be used for both category and topic
-	category: [
-		{
-			text: "appointment-reminder",
-			coding: [
-				{
-					code: "apt-rem",
-					system: "https://example-practice.org"
-				}
-			]
-		}
-	],
-	//...
-	topic: {
-		text: "annual-physical"
-		coding: [
-			{
-				code: "annu-phys",
-				system: "https://example-practice.org"
-			}
-		]
-	}
-}
-```
-
-## Search and GraphQL
+## Querying for Communications with GraphQL
 
 Effectively grouping and filtering your communications makes it easier to search and query for specific data.
 
-For example, if you want to get all of the communications between the provider and a specific patient, you could use the following query. In this, we query for a patient by their id, then search all of the communications that reference them. From these communications, we get the text of the communication, the sender and time it was sent, and the receiver and time it was received. Preview this query in [GraphiQL](graphiql.medplum.com)
+For example, if you want to get all of the communications between the provider and a specific patient, you could use the following query. In this, we query for a patient by their id, returning their name. We then alias our queries their communications as `communicationsSent` and `communicationsReceived`. In these lines, we use the `_reference` keyword to query for any communication that references our patient in the `sender` and `recipient` fields respectively. From these communications, we get the payload of the communication and its content, as well as the sender, receiver, and the time it was sent and received. Preview this query in [GraphiQL](graphiql.medplum.com)
 
 ```
 {
 	# Search for a specific patient by id
-  Patient(id: "example-patient-id") {
+  Patient(id: "36bfa7b5-2b62-4ea8-8a30-c17f4e4831c0") {
+    resourceType
+    id
+		name {
+			family
+			given
+		}
+		# Search for communications that reference the patient as a sender
+    communicationsSent: CommunicationList(_reference: sender) {
+      payload {
+        contentString
+      }
+      # Resolve the practitioners referenced by Communication.recipient
+      recipient {
+        resource {
+          ... on Practitioner {
+            name {
+              family
+              given
+            }
+          }
+        }
+      }
+    }
+    # Search for communications that reference the patient as a recipient
+    communicationsReceived: CommunicationList(_reference: recipient) {
+      payload {
+        contentString
+      }
+      # Resolve the practitioners referenced by Communication.sender
+      sender {
+        resource {
+          ... on Practitioner {
+            name {
+              family
+              given
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+```ts
+await medplum.graphql(`
+{
+  query GetPatientCommunications{
+  Patient(id: "36bfa7b5-2b62-4ea8-8a30-c17f4e4831c0") {
   	resourceType
     id
 		name {
 			family
 			given
 		}
-		# Search for communications that reference the patient
-    communications: CommunicationList(_reference: patient) {
+    communicationsSent: CommunicationList(_reference: sender) {
       payload {
-        div
+        contentString
       }
-      sent
-      sender {
-        resource {
-          ... PractitionerDetails
-        }
-      }
-      received
       recipient {
         resource {
-          ... PatientDetails
+          ... on Practitioner {
+            name {
+              family
+              given
+            }
+          }
+        }
+      }
+    }
+    communicationsReceived: CommunicationList(_reference: recipient) {
+      payload {
+        contentString
+      }
+      sender {
+        resource {
+          ... on Practitioner {
+            name {
+              family
+              given
+            }
+          }
         }
       }
     }
   }
-}
-
-fragment PractitionerDetails on Practitioner {
-	name {
-		family
-		given
-	}
-}
-
-fragment PatientDetails on Patient {
-	name {
-		family
-		given
-	}
-}
+}`);
 ```
 
-Here is an example of how you could search for all communications within your provider that are not linked to an encounter. Using CommunicationList we are able to return a list of all communications that fit our argument of encounter: null. In this case we return the text of the communication, the sender, and the receiver. Preview this query in [GraphiQL](graphiql.medplum.com).
+```curl
+curl -X POST 'https://api.medplum.com/fhir/R4/$graphql' \
+-H "Content-Type: applicatoin/json" \
+-H "Authorization: Bearer $your_access_token" \
+-d '{"query": "query GetPatientCommunications { Patient(id: \"36bfa7b5-2b62-4ea8-8a30-c17f4e4831c0\") { resourceType id name { family given } communicationsSent: CommunicationList(_reference: sender) { payload { contentString } recipient { resource { ... on Practitioner { name { family given } } } } } communicationsReceived: CommunicationList(_reference: recipient) { payload { contentString } sender { resource { ... on Practitioner { name { family given } } } } } } }"}'
+```
+
+Here is an example of how you could search for all communications within your provider that are not linked to an encounter. Using CommunicationList we are able to return a list of all communications that fit our argument of `encounter: null`. In this case we return the text of the communication, the sender, and the receiver. Preview this query in [GraphiQL](graphiql.medplum.com).
 
 ```
 {
 	CommunicationList(encounter: null) {
-		text {
-			div
-		},
+		payload {
+			contentString
+		}
 		sender {
 			resource {
-				... PractitionerDetails
+				... on Practitioner {
+          name {
+            family
+            given
+          }
+        }
 			}
-		},
+		}
 		recipient {
 			resource {
-				... PatientDetails
+				... on Patient {
+          name {
+            family
+            given
+          }
+        }
 			}
 		}
 	}
 }
+```
 
-fragment PractitionerDetails on Practitioner {
-	name {
-		family,
-		given
+```ts
+await medplum.graphql(`
+{
+	CommunicationList(encounter: null) {
+		payload {
+			contentString
+		}
+		sender {
+			resource {
+				... on Practitioner {
+          name {
+            family
+            given
+          }
+        }
+			}
+		}
+		recipient {
+			resource {
+				... on Patient {
+          name {
+            family
+            given
+          }
+        }
+			}
+		}
 	}
 }
+`);
+```
 
-fragment PatientDetails on Patient {
-	name {
-		family,
-		given
-	}
-}
+```curl
+curl -X POST 'https://api.medplum.com/fhir/R4/$graphql' \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer: $your_access_token" \
+-d '{"query":"{ CommunicationList(encounter: null) { payload { contentString } sender { resource { ... on Practitioner { name { family given } } } } recipient { resource { ... on Patient { name { family given } } } } } }"}'
 ```
 
 :::tip Note

--- a/packages/docs/docs/communications/organizing-communications.md
+++ b/packages/docs/docs/communications/organizing-communications.md
@@ -18,7 +18,6 @@ This guide covers different ways that you can organize the `Communication` resou
 ### Building and Organizing Threads
 
 The `Communication` resource cann be used to model threading, allowing you to connect multiple related messages that are part of the same discussion. Threading can best be modeled using the `Communication.topic`, `Communication.partOf`, and `Communication.inResponseTo` elements.
-These fields allow you to reference other communications, establishing a relationship, or thread, between new and existing communications.
 
 The `Communication.topic` element represents a description of the main focus or content of the message. It allows you to link the communication to a specific topic or subject matter. It is easy to think of the topic as if it is the subject line of an email for a given communication. In that sense, it is useful to use that level of specificity when defining a topic. For example, a topic could be an appointment for a given patient on a given date. By assigning this topic to all `Communication` resources that are related to that appointment, you can create a thread of messages about the appointment. An example of this is below:
 
@@ -68,7 +67,7 @@ The `Communication.topic` element represents a description of the main focus or 
 
 The `Communication.partOf` element represents a larger resource of which the communication is a component. It can reference any resource type, allowing us to refer to other `Communication` resources to create a thread. The `partOf` element is best used to create a thread in which each message is linked to a single parent message.
 
-When using the `partOf` field to create a thread, the parent `Communication` resource needs to be distinguished from the children. This is done simply by omitting a message in the `payload` field and a resource referenced in the `partOf` field. Conversely, all children will have both of these fields.
+When using the `partOf` field to create a thread, the parent `Communication` resource needs to be distinguished from the children. This is done simply by omitting a message in the `payload` field and a resource referenced in the `partOf` field, while all children will have both of these fields.
 
 Once we have the parent resource, each message in the thread will create a new `Communication` resource, setting `partOf` to reference the parent resource. As more messages are sent, each one will continue to point to the parent, creating a thread with a common reference point.
 

--- a/packages/docs/docs/communications/organizing-communications.md
+++ b/packages/docs/docs/communications/organizing-communications.md
@@ -48,13 +48,13 @@ In these threads, the parent resource needs to be distinguished from the childre
 
 Additionally, to help organize threads, it is useful to use add a `topic` element to give the thread a subject. Similar to the subject line of an email, the `topic` should be given a high level of specificity to help distinguish the thread. The `topic` should be assigned to both the parent and children `Communication` resources in any thread.
 
-:::Note
+:::note
 
 Because of how specific the `topic` field should be, it is best to use a custom coding rather than `LOINC` or `SNOMED` codes to classify the element.
 
 :::
 
-<details><summary>Example of a thread grouped using a `Communication` resource</summary>
+<details><summary>Example of a thread grouped using a Communication resource</summary>
   <MedplumCodeBlock language="ts" selectBlocks="communicationGroupedThread">
     {ExampleCode}
   </MedplumCodeBlock>
@@ -63,7 +63,7 @@ Because of how specific the `topic` field should be, it is best to use a custom 
 ```mermaid
 
 flowchart BT
-    A["`**Communication.topic:**`" Homer Simpson April 10th lab tests]
+    A[<b>Communication: </b> <br/> Homer Simpson April 10th lab tests]
     B(The specimen for you patient, Homer <br/> Simpson, has been received.) -->|partOf| A
     C(Will the results be ready by the end <br/> of the week?) -->|partOf| A
     D(Yes, we will have them to you <br/> by Thursday.) -->|partOf| A
@@ -92,7 +92,7 @@ Here are some common types of tags that can be used for grouping:
   </MedplumCodeBlock>
 </details>
 
-:::tip Note
+:::tip
 
 There are different ways that you can categorize threads, each one with its own pros and cons. For example, you can have threads with multiple `category` fields, one for specialty and one for level of credentials, etc., where you would search for multiple categories at once. The pros to this are that the data model is more self-explanatory, since each `category` is explicitly represented, and better maintainability, since it is easier to update and add individual categories. However, this can also lead to more complex queries.
 

--- a/packages/docs/docs/communications/organizing-communications.md
+++ b/packages/docs/docs/communications/organizing-communications.md
@@ -176,7 +176,7 @@ To search for specific threads that are grouped by `Encounter`:
 
 In this example, we search for any `Communication` resource that references our `Encounter` in the `encounter` field. We also `_include` that `Encounter`, though you can leave this out if you only want to return the messages themselves. We then use `_sort` to get them in the order they were sent.
 
-### Putting the It All Together
+### Putting It All Together
 
 To put this all together, we can also search for all threads and return their messages with them.
 

--- a/packages/docs/docs/communications/organizing-communications.md
+++ b/packages/docs/docs/communications/organizing-communications.md
@@ -2,43 +2,45 @@
 
 ## Introduction
 
-In a healthcare context, messages are sent all the time and can include many sceanrios (patient to physician, physician to physician, and more), so ensuring they are well-organized is vital. This guide covers how to model and organize threads using Mepdlum.
+In a healthcare context, messages are sent all the time and can include many sceanrios (patient to physician, physician to physician, and more), so ensuring they are well-organized is vital. This guide covers how to model and organize threads using Medplum.
 
-- How to build threads
+- Representing individual messages
+- Building and structuring threads
 - How to "tag" or group threads
-- Querying for and sorting communications and threads
+- Searching for and sorting communications and threads
+
+Representing individual messages with a `Communication` resource
+Put table up here – humanize the language in the descriptions a bit
+
+## Representing Individual Messages
+
+The FHIR `Communication` resource is a representation of any message sent in a healthcare setting. This can include emails, SMS messages, phone calls and more.
+
+| Element       | Description                                                                                      | Relevant Valueset                                                                      | Example                                                   |
+| ------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| payload       | Text, attachments, or resources that are being communicated to the recipient.                    |                                                                                        | You have an appointment scheduled for 2pm.                |
+| sender        | The person or team that sent the message.                                                        |                                                                                        | Practitioner/doctor-alice-smith                           |
+| recipient     | The person or team that received the message.                                                    |                                                                                        | Practitioner/id=doctor-gregory-house                      |
+| topic         | A description of the main focus of the message. Similar to the subject line of an email.         | Custom Internal Code                                                                   | In person physical with Homer Simpson on April 10th, 2023 |
+| category      | The type of message being conveyed. Like a tag that can be applied to the message.               | [SNOMED Codes](http://hl7.org/fhir/R4/valueset-medication-form-codes.html)             | [See below](#building-and-structuring-threads)            |
+| partOf        | A reference to a another resource which the `Communication` is a component.                      |                                                                                        | [See below](#how-to-"tag"-or-group-threads)               |
+| inResponseTo  | A reference to another `Communication` resource which the current one was created to respond to. |                                                                                        | Communication/previous-communication                      |
+| medium        | The technology used for this `Communication` (e.g. email, fax, phone).                           | [Participation Mode Codes](http://terminology.hl7.org/CodeSystem/v3-ParticipationMode) | email                                                     |
+| subject       | A reference to the patient or group that this `Communication` is about.                          |                                                                                        | Patient/homer-simpson                                     |
+| encounter     | A reference to a medical encounter to which this `Communication` is tightly associated.          |                                                                                        | Encounter/example-appointment                             |
+| sent/received | The time that the message was either sent or received.                                           |                                                                                        | 2023-04-10T10:00:00Z                                      |
 
 ## Building and Structuring Threads
 
-The FHIR `Communication` resource is a representation of any message sent in a healthcare setting. In the context of a thread, it is a single message that is a part of a conversation.
-
-| Element       | Description                                                                                      | DataType                                                                                                                                                                                                                                                                                                                                                                                             | Relevant Valueset                                                                      | Example                                                     |
-| ------------- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| payload       | Text, attachments, or resources that are being communicated to the recipient.                    | CommunicationPayload                                                                                                                                                                                                                                                                                                                                                                                 |                                                                                        | contentString: "You have an appointment scheduled for 2pm." |
-| sender        | The entity (e.g. person, practice, care team, etc.) that sent the message.                       | ([Device](/docs/api/fhir/resources/device), [Organization](/docs/api/fhir/resources/organization), [Patient](/docs/api/fhir/resources/patient), [Practitioner](/docs/api/fhir/resources/practitioner), [PractitionerRole](/docs/api/fhir/resources/practitioner-role), [RelatedPerson](/docs/api/fhir/resources/related-person), [HealthcareService](/docs/api/fhir/resources/healthcare-service))[] |                                                                                        | Practitioner/id="123"                                       |
-| recipient     | The entity (e.g. person, practice, care team, etc.) that received the message.                   | ([Device](/docs/api/fhir/resources/device), [Organization](/docs/api/fhir/resources/organization), [Patient](/docs/api/fhir/resources/patient), [Practitioner](/docs/api/fhir/resources/practitioner), [PractitionerRole](/docs/api/fhir/resources/practitioner-role), [RelatedPerson](/docs/api/fhir/resources/related-person), [HealthcareService](/docs/api/fhir/resources/healthcare-service))[] |                                                                                        | Practitioner/id="456"                                       |
-| topic         | A description of the main focus of the message. Like the subject line of an email.               | [CodeableConcept](/docs/api/fhir/resources/codeable-concept)                                                                                                                                                                                                                                                                                                                                         | Custom Internal Code                                                                   | In person physical with Homer Simpson on April 10th, 2023   |
-| category      | The type of message being conveyed. Like a tag that can be applied to the message. See Below.    | [CodeableConcept](/docs/api/fhir/resources/codeable-concept)[]                                                                                                                                                                                                                                                                                                                                       | [SNOMED Codes](http://hl7.org/fhir/R4/valueset-medication-form-codes.html)             | See below                                                   |
-| partOf        | A reference to a larger resource which the `Communication` is a component. See Below.            | Resource[]                                                                                                                                                                                                                                                                                                                                                                                           |                                                                                        | See below                                                   |
-| inResponseTo  | A reference to another `Communication` resource which the current one was created to respond to. | [Communication](/docs/api/fhir/resources/communication)[]                                                                                                                                                                                                                                                                                                                                            |                                                                                        | Communication/id="previous-communication"                   |
-| medium        | The channel used for this `Communication` (e.g. email, fax, phone).                              | [CodeableConcept](/docs/api/fhir/resources/codeable-concept)[]                                                                                                                                                                                                                                                                                                                                       | [Participation Mode Codes](http://terminology.hl7.org/CodeSystem/v3-ParticipationMode) | code: EMAILWRIT, display: Email                             |
-| subject       | A reference to the patient or group that this `Communication` is about.                          | [Patient](/docs/api/fhir/resources/patient), [Group](/docs/api/fhir/resources/group)                                                                                                                                                                                                                                                                                                                 |                                                                                        | Patient/id="789"                                            |
-| encounter     | A reference to a medical encounter to which this `Communication` is tightly associated.          | [Encounter](/docs/api/fhir/resources/encounter)                                                                                                                                                                                                                                                                                                                                                      |                                                                                        | Encounter/id="example-appointment"                          |
-| sent/received | The time that the message was either sent or received.                                           | string                                                                                                                                                                                                                                                                                                                                                                                               |                                                                                        | "2023-04-10T10:00:00Z"                                      |
-
 When building a thread, it is important to consider what type of resource should be used to group the thread together. Depending on the circumstances it makes sense to use different resources.
 
-If the messages are between a patient and a provider, you should use an `Encounter` resource to group the thread. For more details, please see the [Representing Asynchronous Encounters](https://www.medplum.com/docs/communications/async-encounters) docs.
+If the messages are between a patient and a provider, you should use an `Encounter` resource to group the thread. An `Encounter` can be any interaction between a patient and provider, including various types of messages, so it is important that these are classified correctly. For more details, please see the [Representing Asynchronous Encounters](https://www.medplum.com/docs/communications/async-encounters) docs.
 
-However, when a patient is not involved, threads should be grouped using the `Communication` resource with the `partOf` field. A `Communication` will be both a parent resource to represent the thread and a child resource to represent each individual message.
+However, when a patient is not involved, threads should be grouped using the `Communication` resource. A thread will have a two-level hierarchy – one parent `Communication` resource that represents the thread itself, and child `Communication` resources that represent each individual message. The child resources should be linked to the parent using the `partOf` field, which represents a parent resource of which the current `Communication` is a component. This allows you to refer to the parent resource to create a thread where each message is linked to the parent as a common reference point.
 
-The `Communication.partOf` element represents a larger resource of which the current `Communication` is a component. It can reference any resource type, allowing us to refer to other `Communication` resources to create a thread. The `partOf` element creates a thread in which each message is linked to a single parent message.
+In these threads, the parent resource needs to be distinguished from the children. Since the parent resource will not have any content or refer to a parent of its own, this can be done by omitting a message in the `payload` field and a resource reference in the `partOf` field.
 
-When using the `partOf` field to create a thread, the parent `Communication` resource needs to be distinguished from the children. This is done simply by omitting a message in the `payload` field and a resource referenced in the `partOf` field, while all children will have both of these fields.
-
-Once we have the parent resource, each message in the thread will create a new `Communication` resource, setting `partOf` to reference the parent `Communication`. As more messages are sent, each one will continue to point to the parent, creating a thread with a common reference point.
-
-To help organize threads, it is also useful to use the `topic` field. The topic field is like the subject line of an email, and should be given the same level of specificity as you would provide a subject line.
+Additionally, to help organize threads, it is useful to use add a `topic` element to give the thread a subject. Similar to the subject line of an email, the `topic` should be given a high level of specificity to help distinguish the thread. The `topic` should be assigned to both the parent and children `Communication` resources in any thread.
 
 :::Note
 
@@ -155,10 +157,11 @@ Because of how specific the `topic` field should be, it is best to use a custom 
 
 ```mermaid
 
-flowChart TD
-  A[Parent Communication] --> B(The specimen for your patient, Homer Simpson, has been received.)
-  A --> C(Will the results be ready by the end of the week?)
-  A --> D(Yes, we will have them to you by Thursday)
+flowchart BT
+  B(The specimen for you patient, Homer Simpson, has been received.) -->|partOf| A[Homer Simpson April 10th lab tests]
+  C(Will the results be ready by the end of the week?) -->|partOf| A
+  D(Yes, we will have them to you by Thursday.) -->|partOf| A
+  D -->|inResponseTo| C -->|inResponseTo| B
 
 
 ```
@@ -167,15 +170,17 @@ flowChart TD
 
 It can be useful to "tag", or group, threads so that a user can easily reference or interpret a certain type of message at a high level. For example, if there is a thread about a task that needs to be performed by a nurse, it can be tagged as such.
 
-Tagging can be effectively done using the `Communication.category` element, which represents the type of message being conveyed. It allows messages to be classified into different types or groups based on specifications like purpose, nature, or intended audience. It is also important to note that the `category` field is an array, so each `Communication` can have multiple tags.
+Tagging can be effectively done using the `Communication.category` element, which represents the type of message being conveyed. It allows messages to be classified into different types or groups based on specifications like purpose, nature, or intended audience. When assigning a `category` to a thread, it should be included on both the parent and child `Communication` resources. It is also important to note that the `category` field is an array, so each `Communication` can have multiple tags.
 
-:::Note
+Here are some common types of tags that can be used for grouping:
 
-When classifying the `Communication.category` field, it is best to use SNOMED codes. Specifically, for for practitioner roles and clinical specialty, SNOMED provides the [SNOMED Care Team Member Function](https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.30/expansion) valueset.
+| Type of Tag         | Codesystem                                                                                                                                          |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Level of credential | [SNOMED Care Team Member Function valueset](https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.30/expansion)                              |
+| Clinical specialty  | [SNOMED Care Team Member Function valueset](https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.30/expansion)                              |
+| Product offering    | [SNOMED](http://hl7.org/fhir/R4/valueset-medication-form-codes.html), [LOINC](https://www.medplum.com/docs/careplans/loinc), Custom Internal Coding |
 
-:::
-
-<details><summary>Examples of Different Categories</summary>
+<details><summary>Example of Multiple Categories</summary>
 
 ```ts
 {
@@ -227,7 +232,7 @@ Alternatively, you can have threads that have just one `category` that combines 
 
 ## Searching for and Sorting `Communication` Resources
 
-`Communication` resources are easily searchable using the [Medplum Client SDK](/docs/sdk/classes/MedplumClient) `searchResources` method. Throughout this section, we will use an example of threading using `partOf` to reference a single parent `Communication` resource.
+### Searching for All Threads in a System
 
 When searching for threads, we need to differentiate between threads that are grouped by the `Communication` resource and those that are grouped with the `Encounter` resource. We'll begin with threads grouped by `Communication`.
 
@@ -239,15 +244,65 @@ To search for all threads in the system, we need to find each parent `Communicat
 // Search for a Communication-grouped thread
 await medplum.searchResources('Communication', {
   'part-of:missing': true,
-  _revinclude: 'Communication:part-of',
 });
 ```
 
 ```curl
-curl https://api.medplum.com/fhir/R4/Communication?part-of:missing=true&_revinclude=Communication:part-of
+curl https://api.medplum.com/fhir/R4/Communication?part-of:missing=true
 ```
 
-In this example, we use the `:missing` search modifier to search for any `Communication` resources that do not reference another resource in their `partOf` field. However, this would only provide us with the parent `Communication` and none of the actual messages that are part of the thread. In order to get those messages, we use the `_revinclude` search paramter. This parameter adds any `Communication` resources whose `partOf` field references one of the original search results. If you only need the parent resource, you can omit the `_revinclude` field.
+In this example, we use the `:missing` search modifier to search for any `Communication` resources that do not reference another resource in their `partOf` field. This gives us the parent `Communication` of all threads in the system.
+
+### Searching For All Messages in a Thread
+
+Once you have found the thread you want, you may want to retrieve the messages from only that specific thread, in order. In the above example, though we retrieved the messages with each thread, there is no guarantee that they will be in the correct order. You can also filter down results so that you only get the messages specific to the thread you want.
+
+Again, we will separate how to search for `Communication` and `Encounter` grouped threads, beginning with `Communication`.
+
+**Example: **
+
+```ts
+/*
+curl https://api.medplum.com/fhir/R4/Communication?part-of=Communication/example-communication&_sort=sent
+*/
+
+await medplum.searchResources('Communication', {
+  `part-of`: 'Communication/example-communication',
+  _sort: 'sent'
+});
+
+```
+
+In the above example, we search for `Communication` resources that reference our parent in the `partOf` field and sort by the `sent` field. For more details on using the search functionality, see the [Search docs](https://www.medplum.com/docs/search/basic-search).
+
+To search for specific threads that are grouped by `Encounter`:
+
+```ts
+/*
+curl https://api.medplum.com/fhir/R4/Communication?encounter=Encounter/example-encounter&_include=Communication:encounter&_sort=sent
+*/
+
+await medplum.searchResources('Communication', {
+  encounter: 'Encounter/example-encounter',
+  _include: 'Communication:encounter',
+  _sort: 'sent',
+});
+```
+
+In this example, we search for any `Communication` resource that references our `Encounter` in the `encounter` field. We also `_include` that `Encounter`, though you can leave this out if you only want to return the messages themselves. We then use `_sort` to get them in the order they were sent.
+
+### Putting the It All Together
+
+To put this all together, we can also search for all threads and return their messages with them.
+
+```ts
+await medplum.searchResources('Communication', {
+  'part-of:missing': true,
+  _revinclude: 'Communication:part-of',
+});
+```
+
+Here we are using the same initial search to return all of the parent threads in the system. However, we include the `_revinclude` parameter, allowing us to also search for all `Communication` resources that reference one of our search results in the `partOf` field. This allows us to return all of the child messages as well.
 
 Searching for threads grouped by `Encounter` is a little different. Since there is no link from the parent `Encounter` to the child messages, we still search for `Communication` resources at the top level.
 
@@ -265,54 +320,22 @@ await medplum.searchResources('Communication', {
 
 In this example, we set the `encounter:missing` parameter to false, to include only `Communication` resources that reference an encounter. We then use `_include` to include those `Encounter` resources in our search results. Note that this search will include all of the messages as well as the parent resources.
 
-Once you have found the thread you want, you may want to retrieve the messages from only that specific thread, in order. In the above example, though we retrieved the messages with each thread, there is no guarantee that they will be in the correct order. You can also filter down results so that you only get the messages specific to the thread you want.
-
-Again, we will separate how to search for `Communication` and `Encounter` grouped threads, beginning with `Communication`.
-
-**Example: **
+You can also filter down your searches further by including additional parameters.
 
 ```ts
-/*
-curl https://api.medplum.com/fhir/R4/Communication?part-of=Communication/123&_sort=sent
-*/
-
-const communication = { resourceType: 'Communication', id: '123' };
 await medplum.searchResources('Communication', {
-  `part-of`: 'Communication/123',
-  _sort: 'sent'
+  'part-of:missing': true,
+  _revinclude: 'Communication:part-of',
+  subject: 'Patient/example-patient',
 });
 
 // OR
 
-await medplum.searchResources('Communication', {
-  'part-of': getReferenceString(communication),
-  _sort: 'sent'
+await medplum.searchResource('Communication', {
+  'encounter:missing': false,
+  _include: 'Communication:encounter',
+  subject: 'Patient/example-patient',
 });
 ```
 
-In the above example, we search for `Communication` resources that reference our thread in the `partOf` field. This can be done by passing in the reference string or, if you have the `Communication` resource for the thread you want, by using the `getReferenceString` utility method to help construct your query. In addition, we use the `_sort` parameter to sort the results based on the `sent` element. This element represents the time that a `Communication` was sent. You could also use the `received` element, which represents the time that a `Communication` was received. For more details on using the search functionality, see the [Search docs](/docs/search/index).
-
-To search for specific threads that are grouped by `Encounter`:
-
-```ts
-/*
-curl https://api.medplum.com/fhir/R4/Communication?encounter=Encounter/456&_include=Communication:encounter&_sort=sent
-*/
-
-const encounter = { resourceType: 'Encounter', id: '456' };
-await medplum.searchResources('Communication', {
-  encounter: 'Encounter/456',
-  _include: 'Communication:encounter',
-  _sort: 'sent',
-});
-
-// OR
-
-await medplum.searchResources('Communication', {
-  encounter: getReferenceString(encounter),
-  _include: 'Communication:encounter',
-  _sort: 'sent',
-});
-```
-
-In this example, we search for any `Communication` resource that references our `Encounter` in the `encounter` field. We also `_include` that `Encounter`, though you can leave this out if you only want to return the messages themselves. We then use `_sort` to get them in the order they were sent.
+Here we build upon our search by adding the `subject` parameter to search for all threads that are related to a a given patient. For other items to filter your search on, see the [`Communication` Search Parameters](https://www.medplum.com/docs/api/fhir/resources/communication#search-parameters).

--- a/packages/docs/docs/communications/organizing-communications.md
+++ b/packages/docs/docs/communications/organizing-communications.md
@@ -2,13 +2,13 @@
 
 ## Background
 
-Communication in a patient portal can include many scenarios – patient to physician, physician to physician, device to physician, and more. This results in a large volume of communications within a portal, so ensuring that they are well organized is vital. For example, an organization may have staff on call to respond to patient messages. Without proper organization, messages may not reach the correct staff member.
+Communications in a healthcare context (modeled as [Communication](/docs/api/fhir/resources/communication) resources) can include many scenarios – patient to physician, physician to physician, device to physician, and more. This results in a large volume of communications within this context, so ensuring that they are well organized is vital. For example, a provider may have staff on call to respond to patient messages. Without proper organization, messages may not reach the correct staff member.
 
 ## Communication Organization Patterns
 
-There are various ways to organize communications using FHIR, but the most common are `Communication.category` and `Communication.topic`. Additionally, you can use FHIR attirbutes to organize communications using threading.
+There are various ways to organize communications using FHIR, but the most common are `Communication.category` and `Communication.topic`. Additionally, you can use properties such as `Communication.inResponseTo` and `Communication.encounter` to organize communications using threading.
 
-The `Communication.category` element is the type of message being conveyed. Categories can include alerts, notifications, reminders, instructions, etc. Keeping communications well organized by category can help with routing to the correct person/team. For example, communications categorized as appointment reminders that are sent to a patient can automatically be routed to the relevant phsyician as well, alert categories can be automatically routed to on-call staff during off hours, and instruction categories can be automatically routed to the relevenat nurses, patients, physicians, etc.
+The `Communication.category` element is the type of message being conveyed. Categories can include concepts like alerts, notifications, reminders, instructions, etc. Keeping communications well organized by category can help with routing to the correct person/team. For example, communications categorized as appointment reminders that are sent to a patient can automatically be routed to the relevant physician as well, alert categories can be automatically routed to on-call staff during off hours, and instruction categories can be automatically routed to the relevant nurses, patients, physicians, etc.
 
 The `Communication.topic` element is a description of the content of the communication. It’s easy to think of this as the subject line of an email. Keeping communications well organized by topic can assist with billing and driving workflows. For example, if a patient consults with a physician via phone, this communication can be given a topic of, for example `phone-consult`. Being able to see this topic allows for easy billing to the patient. Additionally, a communication with a `prescription-refill-request` topic is an easy indicator to review this request and fulfill it if necessary.
 
@@ -56,7 +56,7 @@ Below is an example of organizing a communication using all three of LOINC, SNOM
 	// An example of how an internal custom coding could be used for both category and topic
 	category: [
 		{
-			text: "Appointment Reminder",
+			text: "appointment-reminder",
 			coding: [
 				{
 					code: "apt-rem",
@@ -67,7 +67,7 @@ Below is an example of organizing a communication using all three of LOINC, SNOM
 	],
 	//...
 	topic: {
-		text: "Annual Physical"
+		text: "annual-physical"
 		coding: [
 			{
 				code: "annu-phys",
@@ -80,7 +80,9 @@ Below is an example of organizing a communication using all three of LOINC, SNOM
 
 ## Search and GraphQL
 
-Effectively organizing your communications makes it easier to search and query for specific data. For example, if you want to get all of the communications between the provider and a specific patient, you could use the following query. In this, we query for a patient by their id, then search all of the communications that reference them. From these communications, we get the text of the communication, the sender and time it was sent, and the receiver and time it was received.
+Effectively gropuing and filtering your communications makes it easier to search and query for specific data.
+
+For example, if you want to get all of the communications between the provider and a specific patient, you could use the following query. In this, we query for a patient by their id, then search all of the communications that reference them. From these communications, we get the text of the communication, the sender and time it was sent, and the receiver and time it was received. Preview this query in [GraphiQL](graphiql.medplum.com)
 
 ```
 {
@@ -128,7 +130,7 @@ fragment PatientDetails on Patient {
 }
 ```
 
-Here is an example of how you could search for all communications within your provider that are not linked to an encounter. Using CommunicationList we are able to return a list of all communications that fit our argument of encounter: null. In this case we return the text of the communication, the sender, and the receiver.
+Here is an example of how you could search for all communications within your provider that are not linked to an encounter. Using CommunicationList we are able to return a list of all communications that fit our argument of encounter: null. In this case we return the text of the communication, the sender, and the receiver. Preview this query in [GraphiQL](graphiql.medplum.com).
 
 ```
 {

--- a/packages/docs/docs/communications/organizing-communications/organizing-communications.md
+++ b/packages/docs/docs/communications/organizing-communications/organizing-communications.md
@@ -1,0 +1,167 @@
+# Organizing Communications
+
+## Background
+
+Communication in a patient portal can include many scenarios – patient to physician, physician to physician, device to physician, and more. This results in a large volume of communications within a portal, so ensuring that they are well organized is vital. For example, an organization may have staff on call to respond to patient messages. Without proper organization, messages may not reach the correct staff member.
+
+## Communication Organization Patterns
+
+There are various ways to organize communications using FHIR, but the most common are `Communication.category` and `Communication.topic`. Additionally, you can use FHIR attirbutes to organize communications using threading.
+
+The `Communication.category` element is the type of message being conveyed. Categories can include alerts, notifications, reminders, instructions, etc. Keeping communications well organized by category can help with routing to the correct person/team. For example, communications categorized as appointment reminders that are sent to a patient can automatically be routed to the relevant phsyician as well, alert categories can be automatically routed to on-call staff during off hours, and instruction categories can be automatically routed to the relevenat nurses, patients, physicians, etc.
+
+The `Communication.topic` element is a description of the content of the communication. It’s easy to think of this as the subject line of an email. Keeping communications well organized by topic can assist with billing and driving workflows. For example, if a patient consults with a physician via phone, this communication can be given a topic of, for example `phone-consult`. Being able to see this topic allows for easy billing to the patient. Additionally, a communication with a `prescription-refill-request` topic is an easy indicator to review this request and fulfill it if necessary.
+
+Organizing communications via threading is an effective way to keep related messages grouped together. In healthcare apps, threads can include SMS chains, in-app chats, email exchanges, and more. These threads can constitute an [encounter](/docs/communications/async-encounters/async-encounters), which can be represented on `Communication.encounter`. The `Communication.encounter` element references a specific encounter that is closely related to the communication, or during which the communication took place. In addition, you can use the `Communication.inResponseTo` element. This element is a an array of references to `Communication` elements that preceded the current one and can be useful for tying all the messages in a threads together. Threading communications in this way allows for users to easily view all messages relevant to a single encounter.
+
+## Codesystems
+
+It is recommended to use LOINC or SNOMED codes to classify `Communication.category` and `Communication.topic`, but it is also possible to use custom coding internal to your practice.
+
+Below is an example of organizing a communication using all three of LOINC, SNOMED, and a custom code.
+
+```
+{
+  resourceType: "Communication",
+	//...
+	category: [
+	  // A category coded using LOINC
+		{
+			text: "Alert",
+			coding: [
+				{
+					code: "74018-3"
+					system: "https://fhir.loinc.org",
+				}
+			]
+		},
+	],
+	//...
+	topic: {
+	  // A topic coded using SNOMED
+		text: "High blood pressure",
+		coding: [
+			{
+				code: "38341003",
+				system: "http://snomed.info/sct",
+				display: "Hypertensive Disorder"
+			}
+		]
+	}
+}
+
+{
+	resourceType: "Communication",
+	//...
+	// An example of how an internal custom coding could be used for both category and topic
+	category: [
+		{
+			text: "Appointment Reminder",
+			coding: [
+				{
+					code: "apt-rem",
+					system: "https://example-practice.org"
+				}
+			]
+		}
+	],
+	//...
+	topic: {
+		text: "Annual Physical"
+		coding: [
+			{
+				code: "annu-phys",
+				system: "https://example-practice.org"
+			}
+		]
+	}
+}
+```
+
+## Search and GraphQL
+
+Effectively organizing your communications makes it easier to search and query for specific data. For example, if you want to get all of the communications between the provider and a specific patient, you could use the following query. In this, we query for a patient by their id, then search all of the communications that reference them. From these communications, we get the text of the communication, the sender and time it was sent, and the receiver and time it was received.
+
+```
+{
+	# Search for a specific patient by id
+  Patient(id: "example-patient-id") {
+    resourceType
+    id
+		name {
+			family
+			given
+		}
+		# Search for communications that reference the patient
+    communications: CommunicationList(_reference: patient) {
+      text {
+        div
+      }
+      sent
+      sender {
+        resource {
+          ... Practitioner
+        }
+      }
+      received
+      recipient {
+        resource {
+          ... Practitioner
+        }
+      }
+    }
+  }
+}
+
+fragment PractitionerDetails on Practitioner {
+	name {
+		family
+		given
+	}
+}
+
+fragment PatientDetails on Patient {
+	name {
+		family
+		given
+	}
+}
+```
+
+Here is an example of how you could search for all communications within your provider that are not linked to an encounter. Using CommunicationList we are able to return a list of all communications that fit our argument of encounter: null. In this case we return the text of the communication, the sender, and the receiver.
+
+```
+{
+	CommunicationList(encounter: null) {
+		text {
+			div
+		},
+		sender {
+			resource {
+				... Practitioner
+			}
+		},
+		recipient {
+			resource {
+				... Patient
+			}
+		}
+	}
+}
+
+fragment PractitionerDetails on Practitioner {
+	name {
+		family,
+		given
+	}
+}
+
+fragment PatientDetails on Patient {
+	name {
+		family,
+		given
+	}
+}
+```
+
+**Note** In these examples, we are only resolving the senders and recipients for one resource type, either Patient or Practitioner. To resolve all potential senders and receivers you will need to include all resource types that can send or receive. For more details on FHIR GraphQL queries see the [GraphQL](/docs/graphql/basic-queries) docs.

--- a/packages/examples/src/communications/organizing-communications.ts
+++ b/packages/examples/src/communications/organizing-communications.ts
@@ -28,7 +28,7 @@ curl 'https://api.medplum.com/fhir/R4/Communication?part-of:missing=true' \
 // start-block searchSpecificThreadTs
 await medplum.searchResources('Communication', {
   'part-of': 'Communication/example-communication',
-  _sort: 'sent'
+  _sort: 'sent',
 });
 // end-block searchSpecificThreadTs
 
@@ -123,7 +123,7 @@ curl 'https://api.medplum.com/fhir/R4/Communication?part-of:missing=true&_revinc
 */
 
 // start-block searchFilteredEncountersTs
-await medplum.searchResource('Communication', {
+await medplum.searchResources('Communication', {
   'encounter:missing': false,
   _include: 'Communication:encounter',
   subject: 'Patient/example-patient',
@@ -142,144 +142,145 @@ curl 'https://api.medplum.com/fhir/R4/Communication?encounter:missing=false&_inc
 // end-block searchFilteredEncountersCurl
 */
 
-const communicationThread: Communication[] = 
-[
-// start-block communicationGroupedThread
-{
-  resourceType: 'Communication',
-  id: 'example-parent-communication',
-  // There is no `partOf` of `payload` field on this communication
-  // ...
-  topic: {
-    text: 'Homer Simpson April 10th lab tests'
-  }
-},
-
-// The initial communication
-{
-  resourceType: 'Communication',
-  id: 'example-message-1',
-  payload: [
-    {
-      id: 'example-message-1-payload',
-      contentString: 'The specimen for you patient, Homer Simpson, has been received.'
-    }
-  ],
-  topic: {
-    text: 'Homer Simpson April 10th lab tests'
-  },
-  // ...
-  partOf: [
-    {
-      resource: {
-        resourceType: 'Communication',
-        id: 'example-parent-communication'
-      }
-    }
-  ]
-},
-
-// A second response, directly to `example-message-1` but still referencing the parent communication
-{
-  resourceType: 'Communication',
-  id: 'example-message-2',
-  payload: [
-    {
-      id: 'example-message-2-payload',
-      contentString: 'Will the results be ready by the end of the week?'
-    }
-  ],
-  topic: {
-    text: 'Homer Simpson April 10th lab tests'
-  },
-  // ...
-  partOf: [
-    {
-      resource: {
-        resourceType: 'Communication',
-        id: 'example-parent-communication'
-      }
-    }
-  ],
-  inResponseTo: [
-    {
-      resource: {
-        resourceType: 'Communication',
-        id: 'example-message-1'
-      }
-    }
-  ]
-},
-
-// A third response
+const communicationThread: Communication[] = [
+  // start-block communicationGroupedThread
   {
     resourceType: 'Communication',
-    id: 'example-message-3',
+    id: 'example-parent-communication',
+    // There is no `partOf` of `payload` field on this communication
+    // ...
+    topic: {
+      text: 'Homer Simpson April 10th lab tests',
+    },
+  },
+
+  // The initial communication
+  {
+    resourceType: 'Communication',
+    id: 'example-message-1',
     payload: [
       {
-        id: 'example-message-2-payload',
-        contentString: 'Yes, we will have them to you by Thursday.'
-      }
+        id: 'example-message-1-payload',
+        contentString: 'The specimen for you patient, Homer Simpson, has been received.',
+      },
     ],
     topic: {
-      text: 'Homer Simpson April 10th lab tests'
+      text: 'Homer Simpson April 10th lab tests',
     },
     // ...
     partOf: [
       {
         resource: {
           resourceType: 'Communication',
-          id: 'example-parent-communication'
-        }
-      }
+          id: 'example-parent-communication',
+        },
+      },
+    ],
+  },
+
+  // A second response, directly to `example-message-1` but still referencing the parent communication
+  {
+    resourceType: 'Communication',
+    id: 'example-message-2',
+    payload: [
+      {
+        id: 'example-message-2-payload',
+        contentString: 'Will the results be ready by the end of the week?',
+      },
+    ],
+    topic: {
+      text: 'Homer Simpson April 10th lab tests',
+    },
+    // ...
+    partOf: [
+      {
+        resource: {
+          resourceType: 'Communication',
+          id: 'example-parent-communication',
+        },
+      },
     ],
     inResponseTo: [
       {
         resource: {
           resourceType: 'Communication',
-          id: 'example-message-2'
-        }
-      }
-    ]
-  }
+          id: 'example-message-1',
+        },
+      },
+    ],
+  },
+
+  // A third response
+  {
+    resourceType: 'Communication',
+    id: 'example-message-3',
+    payload: [
+      {
+        id: 'example-message-2-payload',
+        contentString: 'Yes, we will have them to you by Thursday.',
+      },
+    ],
+    topic: {
+      text: 'Homer Simpson April 10th lab tests',
+    },
+    // ...
+    partOf: [
+      {
+        resource: {
+          resourceType: 'Communication',
+          id: 'example-parent-communication',
+        },
+      },
+    ],
+    inResponseTo: [
+      {
+        resource: {
+          resourceType: 'Communication',
+          id: 'example-message-2',
+        },
+      },
+    ],
+  },
   // end-block communicationGroupedThread
-]
+];
+
+console.log(communicationThread);
 
 const categoryExampleCommunications: Communication =
-// start-block communicationCategories
-{
-  resourceType: 'Communication',
-  id: 'example-communication',
-  category: [
-    {
-      text: 'Doctor',
-      coding: [
-        {
-          code: '158965000',
-          system: 'http://snomed.info/sct'
-        }
-      ]
-    },
-    {
-      text: 'Endocrinology',
-      coding: [
-        {
-          code: '394583002',
-          system: 'http://snomed.info.sct'
-        }
-      ]
-    },
-    {
-      text: 'Diabetes self-management plan',
-      coding: [
-        {
-          code: '735985000',
-          system: 'http://snomed.info.sct'
-        }
-      ]
-    }
-  ]
-}
+  // start-block communicationCategories
+  {
+    resourceType: 'Communication',
+    id: 'example-communication',
+    category: [
+      {
+        text: 'Doctor',
+        coding: [
+          {
+            code: '158965000',
+            system: 'http://snomed.info/sct',
+          },
+        ],
+      },
+      {
+        text: 'Endocrinology',
+        coding: [
+          {
+            code: '394583002',
+            system: 'http://snomed.info.sct',
+          },
+        ],
+      },
+      {
+        text: 'Diabetes self-management plan',
+        coding: [
+          {
+            code: '735985000',
+            system: 'http://snomed.info.sct',
+          },
+        ],
+      },
+    ],
+  };
 // end-block communicationCategories
 
-console.log(communicationThread, categoryExampleCommunications);
+console.log(categoryExampleCommunications);

--- a/packages/examples/src/communications/organizing-communications.ts
+++ b/packages/examples/src/communications/organizing-communications.ts
@@ -1,0 +1,285 @@
+// start-block imports
+import { MedplumClient } from '@medplum/core';
+import { Communication }  from '@medplum/fhirtypes'
+
+// end-block imports
+
+const medplum = new MedplumClient();
+
+// start-block searchParentThreadsTs
+// Search for a Communication-grouped thread
+await medplum.searchResources('Communication', {
+  'part-of:missing': true,
+});
+// end-block searchParentThreadsTs
+
+/*
+// start-block searchParentThreadsCli
+medplum get 'Communication?part-of:missing=true'
+// end-block searchParentThreadsCli
+
+// start-block searchParentThreadsCurl
+curl 'https://api.medplum.com/fhir/R4/Communication?part-of:missing=true' \
+  -H 'authorization: Bearer $ACCESS_TOKEN' \
+  -H 'content-type: application/fhir+json' \
+// end-block searchParentThreadsCurl
+*/
+
+// start-block searchSpecificThreadTs
+await medplum.searchResources('Communication', {
+  'part-of': 'Communication/example-communication',
+  _sort: 'sent'
+});
+// end-block searchSpecificThreadTs
+
+/*
+// start-block searchSpecificThreadCli
+medplum get 'Communication?part-of=Communication/example-communication&_sort=sent'
+// end-block searchSpecificThreadCli
+
+// start-block searchSpecificThreadCurl
+curl 'https://api.medplum.com/fhir/R4/Communication?part-of=Communication/example-communication&_sort=sent' \
+  -H 'authorization: Bearer $ACCESS_TOKEN' \
+  -H 'content-type: application/fhir+json' \
+// end-block searchSpecificThreadCurl
+*/
+
+// start-block searchEncounterThreadTs
+await medplum.searchResources('Communication', {
+  encounter: 'Encounter/example-encounter',
+  _include: 'Communication:encounter',
+  _sort: 'sent',
+});
+// end-block searchEncounterThreadTs
+
+/*
+// start-block searchEncounterThreadCli
+medplum get 'Communication?encounter=Encounter/example-encounter&_include=Communication:encounter&_sort=sent'
+// end-block searchEncounterThreadCli
+
+// start-block searchEncounterThreadCurl
+curl 'https://api.medplum.com/fhir/R4/Communication?encounter=Encounter/example-encounter&_include=Communication:encounter&_sort=sent' \
+  -H 'authorization: Bearer $ACCESS_TOKEN' \
+  -H 'content-type: application/fhir+json' \
+// end-block searchEncounterThreadCurl
+*/
+
+// start-block searchThreadsWithMessagesTs
+await medplum.searchResources('Communication', {
+  'part-of:missing': true,
+  _revinclude: 'Communication:part-of',
+});
+// end-block searchThreadsWithMessagesTs
+
+/*
+// start-block searchThreadsWithMessagesCli
+medplum get 'Communication?part-of:missing=true&_revinclude:Communication:part-of'
+// end-block searchThreadsWithMessagesCli
+
+// start-block searchThreadsWithMessagesCurl
+curl 'https://api.medplum.com/fhir/R4/Communication?part-of:missing=true&_revinclude=Communication:part-of' \
+  -H 'authorization: Bearer $ACCESS_TOKEN' \
+  -H 'content-type: application/fhir+json' \
+// end-block searchThreadsWithMessagesCurl
+*/
+
+// start-block searchEncountersWithMessagesTs
+await medplum.searchResources('Communication', {
+  'encounter:missing': false,
+  _include: 'Communication:encounter',
+});
+// end-block searchEncountersWithMessagesTs
+
+/*
+// start-block searchEncountersWithMessagesCli
+medplum get 'Communication?encounter:missing=false&_include=Communication:encounter'
+// end-block searchEncountersWithMessagesCli
+
+// start-block searchEncountersWithMessagesCurl
+curl 'https://api.medplum.com/fhir/R4/Communication?encounter:missing=false&_include=Communication:encounter' \
+  -H 'authorization: Bearer $ACCESS_TOKEN' \
+  -H 'content-type: application/fhir+json' \
+// end-block searchEncountersWithMessagesCurl
+*/
+
+// start-block searchFilteredThreadsTs
+await medplum.searchResources('Communication', {
+  'part-of:missing': true,
+  _revinclude: 'Communication:part-of',
+  subject: 'Patient/example-patient',
+});
+// end-block searchFilteredThreadsTs
+
+/*
+// start-block searchFilteredThreadsCli
+medplum get 'Communication?part-of:missing=true&_revinclude=Communication:part-of&subject=Patient/example-patient'
+// end-block searchFilteredThreadsCli
+
+// start-block searchFilteredThreadsCurl
+curl 'https://api.medplum.com/fhir/R4/Communication?part-of:missing=true&_revinclude=Communication:part-of&subject=Patient/example-patient' \
+  -H 'authorization: Bearer $ACCESS_TOKEN' \
+  -H 'content-type: application/fhir+json' \
+// end-block searchFilteredThreadsCurl
+*/
+
+// start-block searchFilteredEncountersTs
+await medplum.searchResource('Communication', {
+  'encounter:missing': false,
+  _include: 'Communication:encounter',
+  subject: 'Patient/example-patient',
+});
+// end-block searchFilteredEncountersTs
+
+/*
+// start-block searchFilteredEncountersCli
+medplum get 'Communication?encounter:missing=false&_include=Communication:encounter&subject=Patient/example-patient'
+// end-block searchFilteredEncountersCli
+
+// start-block searchFilteredEncountersCurl
+curl 'https://api.medplum.com/fhir/R4/Communication?encounter:missing=false&_include=Communication:encounter&subject=Patient/example-patient' \
+  -H 'authorization: Bearer $ACCESS_TOKEN' \
+  -H 'content-type: application/fhir+json' \
+// end-block searchFilteredEncountersCurl
+*/
+
+const communicationThread: Communication[] = 
+[
+// start-block communicationGroupedThread
+{
+  resourceType: 'Communication',
+  id: 'example-parent-communication',
+  // There is no `partOf` of `payload` field on this communication
+  // ...
+  topic: {
+    text: 'Homer Simpson April 10th lab tests'
+  }
+},
+
+// The initial communication
+{
+  resourceType: 'Communication',
+  id: 'example-message-1',
+  payload: [
+    {
+      id: 'example-message-1-payload',
+      contentString: 'The specimen for you patient, Homer Simpson, has been received.'
+    }
+  ],
+  topic: {
+    text: 'Homer Simpson April 10th lab tests'
+  },
+  // ...
+  partOf: [
+    {
+      resource: {
+        resourceType: 'Communication',
+        id: 'example-parent-communication'
+      }
+    }
+  ]
+},
+
+// A second response, directly to `example-message-1` but still referencing the parent communication
+{
+  resourceType: 'Communication',
+  id: 'example-message-2',
+  payload: [
+    {
+      id: 'example-message-2-payload',
+      contentString: 'Will the results be ready by the end of the week?'
+    }
+  ],
+  topic: {
+    text: 'Homer Simpson April 10th lab tests'
+  },
+  // ...
+  partOf: [
+    {
+      resource: {
+        resourceType: 'Communication',
+        id: 'example-parent-communication'
+      }
+    }
+  ],
+  inResponseTo: [
+    {
+      resource: {
+        resourceType: 'Communication',
+        id: 'example-message-1'
+      }
+    }
+  ]
+},
+
+// A third response
+  {
+    resourceType: 'Communication',
+    id: 'example-message-3',
+    payload: [
+      {
+        id: 'example-message-2-payload',
+        contentString: 'Yes, we will have them to you by Thursday.'
+      }
+    ],
+    topic: {
+      text: 'Homer Simpson April 10th lab tests'
+    },
+    // ...
+    partOf: [
+      {
+        resource: {
+          resourceType: 'Communication',
+          id: 'example-parent-communication'
+        }
+      }
+    ],
+    inResponseTo: [
+      {
+        resource: {
+          resourceType: 'Communication',
+          id: 'example-message-2'
+        }
+      }
+    ]
+  }
+  // end-block communicationGroupedThread
+]
+
+const categoryExampleCommunications: Communication =
+// start-block communicationCategories
+{
+  resourceType: 'Communication',
+  id: 'example-communication',
+  category: [
+    {
+      text: 'Doctor',
+      coding: [
+        {
+          code: '158965000',
+          system: 'http://snomed.info/sct'
+        }
+      ]
+    },
+    {
+      text: 'Endocrinology',
+      coding: [
+        {
+          code: '394583002',
+          system: 'http://snomed.info.sct'
+        }
+      ]
+    },
+    {
+      text: 'Diabetes self-management plan',
+      coding: [
+        {
+          code: '735985000',
+          system: 'http://snomed.info.sct'
+        }
+      ]
+    }
+  ]
+}
+// end-block communicationCategories
+
+console.log(communicationThread, categoryExampleCommunications);

--- a/packages/examples/src/communications/organizing-communications.ts
+++ b/packages/examples/src/communications/organizing-communications.ts
@@ -1,6 +1,6 @@
 // start-block imports
 import { MedplumClient } from '@medplum/core';
-import { Communication }  from '@medplum/fhirtypes'
+import { Communication } from '@medplum/fhirtypes';
 
 // end-block imports
 
@@ -154,7 +154,7 @@ const communicationThread: Communication[] = [
     },
   },
 
-  // The initial communication
+  // The initial message
   {
     resourceType: 'Communication',
     id: 'example-message-1',
@@ -178,7 +178,7 @@ const communicationThread: Communication[] = [
     ],
   },
 
-  // A second response, directly to `example-message-1` but still referencing the parent communication
+  // A response directly to `example-message-1` but still referencing the parent communication
   {
     resourceType: 'Communication',
     id: 'example-message-2',
@@ -210,7 +210,7 @@ const communicationThread: Communication[] = [
     ],
   },
 
-  // A third response
+  // A second response
   {
     resourceType: 'Communication',
     id: 'example-message-3',


### PR DESCRIPTION
I've written the documentation for organizing communications. I've forked and cloned the Medplum repo and am just creating this pull request as a comparison to my local copy. I added the docs following your outline from the issue page. Looking at your other docs, I don't think this is how you generally put code in to them, but I thought this would be easier for now for you to review. Let me know what you think and if you have any questions.
